### PR TITLE
fix: replace afterUpload, so that the url returns corresponds the url…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 yarn-error.log
 temp.js
 package-lock.json
+.eslintrc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picgo-plugin-super-prefix",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A PicGo plugin for elegant file name prefix",
   "main": "dist/index.js",
   "publishConfig": {
@@ -23,17 +23,19 @@
   "author": "gclove",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^10.10.1",
-    "eslint": "^5.0.1",
-    "eslint-config-standard": "^11.0.0",
-    "eslint-plugin-import": "^2.13.0",
-    "eslint-plugin-node": "^6.0.1",
-    "eslint-plugin-promise": "^3.8.0",
+    "@types/node": "16.9.1",
+    "@typescript-eslint/eslint-plugin": "^5.40.0",
+    "@typescript-eslint/parser": "^5.40.0",
+    "eslint-config-standard-with-typescript": "^23.0.0",
+    "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-standard": "^3.1.0",
-    "picgo": "^1.2.0",
-    "tslint": "^5.10.0",
-    "tslint-config-standard": "^7.1.0",
-    "typescript": "^3.0.3"
+    "picgo": "^1.5.0-alpha.13",
+    "typescript": "^4.8.4",
+    "eslint": "^8.25.0",
+    "eslint-config-standard": "^17.0.0",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-n": "^15.3.0",
+    "eslint-plugin-promise": "^6.1.0"
   },
   "dependencies": {
     "dayjs": "^1.8.17"


### PR DESCRIPTION
## Problem info

The plugin only change the url to upload, but return url is not changed. As a result, uploaded img cannot be shown because invariant url. **Issue #9** 

Specifically, the url uploaded is `prefix + fileName + extName`, but what we got is only `fileName + extName`, as we do not process what uploader returns.

Referrence:
![image](https://github.com/gclove/picgo-plugin-super-prefix/assets/68414883/451a8a51-82bd-4222-8afd-3a750a958a1e)

 
## Patch
+ add afterUploadHandle
+ refactor two handlers to separate functions