### PR TITLE
fix: replace afterUpload, so that the url returns corresponds the url…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 yarn-error.log
 temp.js
 package-lock.json
+.eslintrc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picgo-plugin-super-prefix",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A PicGo plugin for elegant file name prefix",
   "main": "dist/index.js",
   "publishConfig": {
@@ -23,17 +23,19 @@
   "author": "gclove",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^10.10.1",
-    "eslint": "^5.0.1",
-    "eslint-config-standard": "^11.0.0",
-    "eslint-plugin-import": "^2.13.0",
-    "eslint-plugin-node": "^6.0.1",
-    "eslint-plugin-promise": "^3.8.0",
+    "@types/node": "16.9.1",
+    "@typescript-eslint/eslint-plugin": "^5.40.0",
+    "@typescript-eslint/parser": "^5.40.0",
+    "eslint-config-standard-with-typescript": "^23.0.0",
+    "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-standard": "^3.1.0",
-    "picgo": "^1.2.0",
-    "tslint": "^5.10.0",
-    "tslint-config-standard": "^7.1.0",
-    "typescript": "^3.0.3"
+    "picgo": "^1.5.0-alpha.13",
+    "typescript": "^4.8.4",
+    "eslint": "^8.25.0",
+    "eslint-config-standard": "^17.0.0",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-n": "^15.3.0",
+    "eslint-plugin-promise": "^6.1.0"
   },
   "dependencies": {
     "dayjs": "^1.8.17"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,88 @@
-import picgo from 'picgo'
+import { PicGo } from 'picgo'
 import dayjs from 'dayjs'
 
 function sleep (time) {
   return new Promise((resolve) => setTimeout(resolve, time))
+}
+
+async function beforeUploadHandle (ctx) {
+  const autoRename = ctx.getConfig('settings.autoRename');
+  if (autoRename) {
+    ctx.emit('notification', {
+      title: '❌ 警告',
+      body: '请关闭 PicGo 的 &#8203;``【oaicite:0】``&#8203; 功能,\nsuper-prefix 插件重命名方式会被覆盖',
+    });
+    await sleep(10000);
+    throw new Error('super-prefix conflict');
+  }
+
+  let userConfig = ctx.getConfig('picgo-plugin-super-prefix');
+  if (!userConfig) {
+    userConfig = {
+      prefix: '',
+      fileFormat: '',
+    };
+  }
+
+  for (let i = 0; i < ctx.output.length; i++) {
+    let fileName = ctx.output[i].fileName;
+    let prefix = '';
+    if (userConfig.prefixFormat !== undefined && userConfig.prefixFormat !== '') {
+      prefix = dayjs().format(userConfig.prefixFormat);
+    }
+
+    if (userConfig.fileFormat !== undefined && userConfig.fileFormat !== '') {
+      if (i > 0) {
+        fileName = prefix + dayjs().format(userConfig.fileFormat) + '-' + i + ctx.output[i].extname;
+      } else {
+        fileName = prefix + dayjs().format(userConfig.fileFormat) + ctx.output[i].extname;
+      }
+    } else {
+      fileName = prefix + fileName;
+    }
+
+    ctx.output[i].fileName = fileName;
+  }
+}
+
+async function afterUploadHandle (ctx) {
+  const autoRename = ctx.getConfig('settings.autoRename');
+  if (autoRename) {
+    ctx.emit('notification', {
+      title: '❌ 警告',
+      body: '请关闭 PicGo 的 &#8203;``【oaicite:0】``&#8203; 功能,\nsuper-prefix 插件重命名方式会被覆盖',
+    });
+    await sleep(10000);
+    throw new Error('super-prefix conflict');
+  }
+
+  let userConfig = ctx.getConfig('picgo-plugin-super-prefix');
+  if (!userConfig) {
+    userConfig = {
+      prefix: '',
+      fileFormat: '',
+    };
+  }
+
+  for (let i = 0; i < ctx.output.length; i++) {
+    let url = ctx.output[i].imgUrl;
+    let tmpArray = url.split("/");
+
+    if (tmpArray.length <= 0)
+      continue;
+
+    let fileName = tmpArray[tmpArray.length - 1];
+    let prefix = "";
+    if (userConfig.prefixFormat !== undefined && userConfig.prefixFormat !== '') {
+      prefix = dayjs().format(userConfig.prefixFormat);
+    }
+
+    fileName = prefix + fileName;
+    tmpArray[tmpArray.length - 1] = fileName;
+    url = tmpArray.join("/");
+
+    ctx.output[i].imgUrl = url;
+  }
 }
 
 const pluginConfig = ctx => {
@@ -30,49 +110,14 @@ const pluginConfig = ctx => {
   ]
 }
 
-export = (ctx: picgo) => {
-  const register = () => {
+export = (ctx: PicGo) => {
+  const register = (): void => {
     ctx.helper.beforeUploadPlugins.register('super-prefix', {
-      async handle (ctx) {
-        // console.log(ctx)
-        const autoRename = ctx.getConfig('settings.autoRename')
-        if (autoRename) {
-          ctx.emit('notification', {
-            title: '❌ 警告',
-            body: '请关闭 PicGo 的 【时间戳重命名】 功能,\nsuper-prefix 插件重命名方式会被覆盖'
-          })
-          await sleep(10000)
-          throw new Error('super-prefix conflict')
-        }
-
-        let userConfig = ctx.getConfig('picgo-plugin-super-prefix')
-        if (!userConfig) {
-          userConfig = {
-            prefix: '',
-            fileFormat: ''
-          }
-        }
-
-        for (let i = 0; i < ctx.output.length; i++) {
-          let fileName = ctx.output[i].fileName
-          let prefix = ''
-          if (userConfig.prefixFormat != undefined && userConfig.prefixFormat != '') {
-            prefix = dayjs().format(userConfig.prefixFormat)
-          }
-
-          if (userConfig.fileFormat != undefined && userConfig.fileFormat != '') {
-            if (i > 0) {
-              fileName = prefix + dayjs().format(userConfig.fileFormat) + '-' + i + ctx.output[i].extname
-            } else {
-              fileName = prefix + dayjs().format(userConfig.fileFormat) + ctx.output[i].extname
-            }
-          }else{
-            fileName = prefix + fileName
-          }
-          
-          ctx.output[i].fileName = fileName
-        }
-      },
+      handle: beforeUploadHandle, 
+      config: pluginConfig
+    })
+    ctx.helper.afterUploadPlugins.register('super-prefix', {
+      handle: afterUploadHandle,
       config: pluginConfig
     })
   }


### PR DESCRIPTION
## Problem info

The plugin changes the dirname and filename before upload, but in return url dir name is missing. As a result, uploaded img cannot be shown because invariant url. **Issue #9** 

Specifically, the filename uploaded is `prefix + fileName + extName`, but what we got is only `fileName + extName`, what happened is:
```
# Before upload
beforeUploadPlugins: super-prefix running # result is right: 2023/2023-11-15/2023-11-15T03:36:58.png
# Uploader finished
Uploading... Current uploader is [gitee]  # result is wrong: 2023-11-15T03:36:58.png
```

So we should rename again after uploading:
```
# Before upload
beforeUploadPlugins: super-prefix running # result is right: 2023/2023-11-15/2023-11-15T03:36:58.png
# Uploader finished
Uploading... Current uploader is [gitee]  # result is wrong: 2023-11-15T03:36:58.png
# After upload
afterUploadPlugins: super-prefix running  # result is right: 2023/2023-11-15/2023-11-15T03:36:58.png
```

Referrence:
![image](https://github.com/gclove/picgo-plugin-super-prefix/assets/68414883/451a8a51-82bd-4222-8afd-3a750a958a1e)

 
## Patch
+ add afterUploadHandle
+ refactor two handlers to separate functions